### PR TITLE
make scour find+rm more robust to filenames

### DIFF
--- a/scour/scour.in
+++ b/scour/scour.in
@@ -147,9 +147,8 @@ while read dir age pattern; do
 			BEFORE=`du -s . 2>/dev/null | \
 			    sed 's/^ *\([0-9]*\).*/\1/'`
 		    fi
-		    find . -type f -mtime +$FINDAGE -name "$pattern" -print \
-                        | sed 's/\([^\n]\)/\\\1/g' \
-                        | xargs rm -f && touch ".scour$pattern"
+		    find . -type f -mtime +$FINDAGE -name "$pattern" -exec \
+                        rm -f {} + && touch ".scour$pattern"
 		    if [ "$VERBOSEFLAG" != "" ]
 		    then
 			AFTER=`du -s . 2>/dev/null | \


### PR DESCRIPTION
Filenames with quotes or other characters may cause xargs to fail like so
$ ldmadmin scour
xargs: unmatched single quote; by default quotes are special to xargs unless you use the -0 option

Use POSIX `-exec rm -f {} +` which should be more forgiving.