### PR TITLE
Added SIGHUP handler used to reopen log file.

### DIFF
--- a/noaaport/noaaportIngester.c
+++ b/noaaport/noaaportIngester.c
@@ -362,6 +362,9 @@ static void signal_handler(
 #endif
 
     switch (sig) {
+        case SIGHUP:
+            closeulog();
+            break;
         case SIGTERM:
             done = 1;
             if (fifo)
@@ -427,7 +430,6 @@ static void set_sigactions(void)
 
     /* Ignore these */
     sigact.sa_handler = SIG_IGN;
-    (void)sigaction(SIGHUP, &sigact, NULL);
     (void)sigaction(SIGALRM, &sigact, NULL);
     (void)sigaction(SIGCHLD, &sigact, NULL);
     (void)sigaction(SIGCONT, &sigact, NULL);
@@ -444,6 +446,7 @@ static void set_sigactions(void)
     sigact.sa_flags |= SA_RESTART;
 #endif
     (void)sigaction(SIGUSR2, &sigact, NULL);
+    (void)sigaction(SIGHUP, &sigact, NULL);
 }
 
 /**


### PR DESCRIPTION
I work for the Data Center at the University of Wisconsin-Madison Space Science and Engineering Center. In the past we have used (r)syslog with noaaportIngester to log messages for each NOAAPORT channel as suggested by the installation documentation:
`EXEC	"noaaportIngester -m 224.0.1.1 -n -u 3"` (in ~ldm/etc/ldmd.conf)
`local3.debug   /usr/local/ldm/logs/nwstg.log` (in /etc/rsyslog.conf)

However, our IT group recently began utilizing rsyslog for remote logging, so we are now logging directly to files:
`EXEC	"noaaportIngester -m 224.0.1.1 -n -l /usr/local/ldm/logs/nwstg.log"` (~ldm/etc/ldmd.conf)

After changing to this direct logging method, our log rotation scripts are no longer working as before. With (r)syslog, we could rotate our logs by renaming the log files and then running hupsyslog (provided with LDM). When logging directly to files, there does not currently seem to be a way to rename currently open log files and open a new log file with the original name (without completely killing the noaaportIngester processes or restarting LDM).

I have modified noaaportIngester.c to call `closeulog()` when it receives SIGHUP, allowing us to rotate these log files without any noaaportIngester downtime (similarly to what we did previously with syslog).