### PR TITLE
Mi cscour

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -502,6 +502,8 @@ AC_DEFINE_UNQUOTED([PQACT_CONFIG_PATH], ["$sysconfdir/pqact.conf"],
     [Default pathname of pqact(1) configuration-file])
 AC_DEFINE_UNQUOTED([LDM_CONFIG_PATH], ["$sysconfdir/ldmd.conf"],
     [Default pathname of LDM configuration-file])
+AC_DEFINE_UNQUOTED([SCOUR_CONFIG_PATH], ["$sysconfdir/scour.conf"],
+    [Default pathname of scour(1) configuration-file])
 AC_DEFINE_UNQUOTED([SCOUR_EXCLUDE_PATH], ["$sysconfdir/scour_excludes.conf"],
     [Default pathname of file containing directories-to-be-excluded by scour(1)])
 AC_DEFINE_UNQUOTED([PQACT_DATA_DIR], ["$localstatedir/data"],

--- a/scour/parser.c
+++ b/scour/parser.c
@@ -365,7 +365,9 @@ startsWithTilda(char *dirPath, char *expandedDirName)
 	}
 	return 0;
 }
-
+    
+    
+    
 /**
  * Checks the directory path name present in the scour configuration file
  * to validate the entries there, as far as existence of directory, non-exclusion
@@ -398,12 +400,12 @@ vetThisDirectoryPath(char * dirName, char (*excludedDirsList)[PATH_MAX],
 	// 2. check if dirName is in the list of excluded direectories. 
 	// If not continue the vetting process
 	// dirtName is an absolute path. Excluded dirs are expected to be too.
-	log_info("Is path %s  an excluded directory?", dirName);
+	
 	if( isExcluded(dirName, excludedDirsList, excludedDirsCounter) ) return -1;
-	log_info("Is path %s  an excluded directory?", dirName);
+	
 	// 3. check that the directory is a valid one
     if( isNotAccessible(dirName) ) return -1;
-	log_info("Is path %s  NOT ACCESSIBLE directory?", dirName);
+	
 	// 4. check if dir is /home/<userName> and compare with getLogin() --> /home/<userName>
 	//    error if same (dirName should not be /home/<user>)
 	if( isSameAsLoginDirectory(dirName) ) return -1;

--- a/scour/parser.c
+++ b/scour/parser.c
@@ -64,138 +64,6 @@
 #include "globals.h"
 #include "registry.h"
 
-// scour configuration file
-extern char *ingestFilename;
-
-// Pathname of file containing directories to be excluded from scouring
-static char excludePath[PATH_MAX];
-
-static void 
-usage(const char* progname)
-{
-    log_add(
-"Usage:\n"
-"       %s [-v] [-d] [-e exclude_path] [-l dest] [scour_configuration_pathname]\n"
-"Where:\n"
-"  -d               Enable directory deletion\n"
-"  -e exclude_path  Pathname of file listing directories to be excluded. "
-                    "Default is \n"
-"                   \"%s\".\n"
-"  -l dest          Log to `dest`. One of: \"\" (system logging daemon), \"-\"\n"
-"                   (standard error), or file `dest`. Default is\n"
-"                   \"%s\".\n"
-"  -v               Log INFO messages\n",
-            progname,
-            excludePath,
-            log_get_default_destination());
-    log_flush_error();
-}
-
-/**
- * Checks if 'path' is a regular file.
- *
- * @param[in]  path 		 scour config file
- * @retval     0             boolean false: 'path' is NOT a regular file                           
- * @retval     !0            boolean true: 'path' is a regular file
- */
-static bool 
-isRegularFile(const char *path)
-{
-    struct stat path_stat;
-
-    if (stat(path, &path_stat) == -1)
-    {
-        return false;
-    }
-
-    return (S_ISREG(path_stat.st_mode)) ? true : false;
-}
-
-
-/**
- * Parses the command line options for the Cscour program
- *
- * @param[in]  argc          	Number of operands.
- * @param[in]  argv          	Operands.
- * @param[in]  deleteDirOption 	Delete or not option
- *
- */
-void 
-parseArgv(int argc, char ** argv, int *deleteDirOption)
-{
-    const char* const   progname = basename(argv[0]);
-    char*       var;
-
-    if (reg_getString(REG_SCOUR_EXCLUDE_PATH, &var)) {
-        strncpy(excludePath, SCOUR_EXCLUDE_PATH, sizeof(excludePath)-1);
-    }
-    else {
-        strncpy(excludePath, var, sizeof(excludePath)-1);
-        free(var);
-    }
-
-    *deleteDirOption = 0;
-    int ch;
-    char logFilename[PATH_MAX]="";
-
-    extern int optind;
-    extern int opterr;
-    extern char *optarg;
-
-    opterr = 0;
-    while (( ch = getopt(argc, argv, ":de:vl:")) != -1) {
-
-        switch (ch) {
-
-        case 'd': 	{
-        			*deleteDirOption = 1;
-        			break;
-        		}
-        case 'e':   {
-                    (void)strncpy(excludePath, optarg, sizeof(excludePath)-1);
-                    break;
-                }
-        case 'l':  	{
-        			if (log_set_destination(optarg)) {
-						log_syserr("Couldn't set logging destination to \"%s\"", optarg);
-						usage(progname);
-					}
-					strcpy(logFilename, optarg);
-					log_info("logfilename: %s", logFilename);
-					break;
-            	}
-        case 'v':  {
-        			if (!log_is_enabled_info)
-                    	log_set_level(LOG_LEVEL_INFO);
-                    break;
-                }
-        case ':': {
-                    log_add("Option \"-%c\" requires a positional argument", ch);                
-                    usage(progname);
-                    exit(EXIT_SUCCESS);                   
-                }
-		default:	{
-			        log_add("Unknown option: \"%c\"", ch);
-                    usage(progname);
-                    exit(EXIT_SUCCESS);
-				}
-        }
-    }
-
-	if(argc - optind > 1)  usage(progname);
-    
-    ingestFilename = argv[optind];
-
- 	// check if exists:
- 	if( !isRegularFile( ingestFilename )  ) 
- 	{
-    	// file doesn't exist
-    	log_add("Scour configuration file (%s) does not exist (or is not a text file)! Bailing out...", 
-    		ingestFilename);
-    	log_flush_error();
-    	exit(EXIT_FAILURE);
-	}
-}
 
 /**
  * Builds a list of to-be-excluded directory paths (not scoured)
@@ -207,14 +75,14 @@ parseArgv(int argc, char ** argv, int *deleteDirOption)
  * @retval     -1            error in opening the DIRS_TO_EXCLUDE_FILE file
  */
 int 
-getListOfDirsToBeExcluded(char (*list)[PATH_MAX])
+getListOfDirsToBeExcluded(char (*list)[PATH_MAX], char *excludedDirsPath)
 {
     FILE *fp = NULL;
 
-    if((fp = fopen(DIRS_TO_EXCLUDE_FILE, "r")) == NULL)
+    if((fp = fopen(excludedDirsPath, "r")) == NULL)
     {
     	log_add("fopen(\"%s\") failed: %s",
-            DIRS_TO_EXCLUDE_FILE, strerror(errno));
+            excludedDirsPath, strerror(errno));
 		log_flush_warning();
 
         return -1;
@@ -246,13 +114,13 @@ getListOfDirsToBeExcluded(char (*list)[PATH_MAX])
  * @retval      -1                   error occurred
  */
 int
-parseConfig(int *directoriesCounter, IngestEntry_t** listHead)
+parseConfig(int *directoriesCounter, IngestEntry_t** listHead, char *excludedDirsPath, char *scourConfPath)
 {
 	
-	//const char* ingestFilename = SCOUR_INGEST_FILENAME;
+	//const char* scourConfPath = SCOUR_INGEST_FILENAME;
     char rejectedDirPathsList[MAX_NOT_ALLOWED_DIRPATHS][PATH_MAX];
 
-	int excludedDirsCounter = getListOfDirsToBeExcluded(rejectedDirPathsList);
+	int excludedDirsCounter = getListOfDirsToBeExcluded(rejectedDirPathsList, excludedDirsPath);
 
     FILE *fp = NULL;	
     int entryCounter = 0;
@@ -264,9 +132,9 @@ parseConfig(int *directoriesCounter, IngestEntry_t** listHead)
 	char delim[] = " \t\n"; // space, tab and new line
     size_t len = 0;
 
-    if((fp = fopen(ingestFilename, "r")) == NULL)
+    if((fp = fopen(scourConfPath, "r")) == NULL)
     {
-        log_add_syserr("fopen(\"%s\") failed", ingestFilename);
+        log_add_syserr("fopen(\"%s\") failed", scourConfPath);
         return -1;
     }
 

--- a/scour/parser.c
+++ b/scour/parser.c
@@ -81,7 +81,7 @@ getListOfDirsToBeExcluded(char (*list)[PATH_MAX], char *excludedDirsPath)
 
     if((fp = fopen(excludedDirsPath, "r")) == NULL)
     {
-    	log_add("fopen(\"%s\") failed: %s",
+    	log_add("Directory excluded file: fopen(\"%s\") failed: %s. (Skipped.)",
             excludedDirsPath, strerror(errno));
 		log_flush_warning();
 
@@ -92,13 +92,6 @@ getListOfDirsToBeExcluded(char (*list)[PATH_MAX], char *excludedDirsPath)
     while((fscanf(fp,"%s", list[i])) !=EOF) //scanf and check EOF
     {
 		if(list[i][0] == '#' || list[i][0] == '\n' ) continue;
-
- 		// printf("list[%i] is '%s'\n", i, list[i]);
-
-    	/*  OR, with pointer
-		if((plist + i)[0] == '#' || (plist + i)[0] == '\n' ) continue;
-        printf("list[%i] is '%s'\n", i, plist + i);
-		*/
         i++;
     }
 	return i;

--- a/scour/parser.h
+++ b/scour/parser.h
@@ -33,7 +33,8 @@
 #define DAYS_SINCE_1994 9516
 
 #define MAX_NOT_ALLOWED_DIRPATHS 100
-#define DIRS_TO_EXCLUDE_FILE "/tmp/scourExcludedDirectories.txt"
+#define REG_SCOUR_EXCLUDE_PATH "/scour/exclude-path"
+
 
 typedef struct IngestEntry {
 
@@ -44,9 +45,9 @@ typedef struct IngestEntry {
 	struct IngestEntry* nextEntry;
 } IngestEntry_t;
 
-void  parseArgv(int, char **, int *);
+void  parseArgv(int, char **, int *, char *);
 void  newEntryNode(IngestEntry_t **, char *, char *, char *);
-int   parseConfig(int *, IngestEntry_t **);
+int   parseConfig(int *, IngestEntry_t **, char *, char *);
 int   regexOps(char *, char *, int);
 int   nowInEpoch();
 int   convertDaysOldToEpoch(char *);

--- a/scour/parser.h
+++ b/scour/parser.h
@@ -33,8 +33,6 @@
 #define DAYS_SINCE_1994 9516
 
 #define MAX_NOT_ALLOWED_DIRPATHS 100
-#define REG_SCOUR_EXCLUDE_PATH "/scour/exclude-path"
-
 
 typedef struct IngestEntry {
 

--- a/scour/testCscour.py
+++ b/scour/testCscour.py
@@ -24,8 +24,8 @@
  #
 
 
-
 import os
+from os import system
 from os import path
 from pathlib import Path
 import time
@@ -34,487 +34,508 @@ from subprocess import PIPE
 import sys
 import errno
 import shutil
+import argparse
 
-ASSERT_FILE_DELETED			="Expect file to be deleted"
-ASSERT_FILE_LINK_DELETED	="Expect file and its symlink be deleted"
-ASSERT_DIR_DELETED			="Expect directory to be deleted"
-ASSERT_NOT_DIR				="Expect not a directory to be skipped"
-ASSERT_DIR_LINK_NOT_DELETED	="Expect directory and symlink NOT be deleted"
+ASSERT_FILE_DELETED            ="Expect file to be deleted"
+ASSERT_FILE_LINK_DELETED    ="Expect file and its symlink be deleted"
+ASSERT_DIR_DELETED            ="Expect directory to be deleted"
+ASSERT_NOT_DIR                ="Expect not a directory to be skipped"
+ASSERT_DIR_LINK_NOT_DELETED    ="Expect directory and symlink NOT be deleted"
 
-ASSERT_SUCCESS				="SUCCESS"
-ASSERT_FAIL					="FAIL"
+ASSERT_SUCCESS                ="SUCCESS"
+ASSERT_FAIL                    ="FAIL"
 
 class CommonFileSystem:
 
-	dirList=[
-			"/tmp/vesuvius",
-			"/tmp/etna",
-			"/tmp/etna/alt_dir"
-		]		
+    dirList=[
+            "/tmp/vesuvius",
+            "/tmp/etna",
+            "/tmp/etna/alt_dir"
+        ]        
 
-	fileList=["/tmp/vesuvius/.scour$*.foo", 
-				"/tmp/vesuvius/precipitation.foo",
-				"/tmp/vesuvius/precipitation.txt",
-				"/tmp/etna/precipitation.txt",
-				"/tmp/etna/alt_dir/precipitation.txt",
-				"/tmp/etna/vesuvius.foo",
-				"/tmp/etna/.scour$*.foo"
-				]
+    fileList=["/tmp/vesuvius/.scour$*.foo", 
+                "/tmp/vesuvius/precipitation.foo",
+                "/tmp/vesuvius/precipitation.txt",
+                "/tmp/etna/precipitation.txt",
+                "/tmp/etna/alt_dir/precipitation.txt",
+                "/tmp/etna/vesuvius.foo",
+                "/tmp/etna/.scour$*.foo"
+                ]
 
-	def __init__(self, filename, timestamp):
-		self.filename = filename
-		self.timestamp = timestamp
+    def __init__(self, filename, timestamp):
+        self.filename = filename
+        self.timestamp = timestamp
 
-	def __str__(self):
-		return f"{self.filename}  {self.timestamp}"
+    def __str__(self):
+        return f"{self.filename}  {self.timestamp}"
 
-	__repr__ = __str__
+    __repr__ = __str__
 
-	def __eq__(self, other):
-		if self.filename == other.filename:
-			return true
-		return false
+    def __eq__(self, other):
+        if self.filename == other.filename:
+            return true
+        return false
 
-	def changeIt(self, timestamp):
-		self.timestamp = timestamp
-		return self;
+    def changeIt(self, timestamp):
+        self.timestamp = timestamp
+        return self;
 
-	def createFiles(fileList):
+    def createFiles(fileList, debug):
 
-		for file in fileList:
-			expandedFile =  os.path.expanduser(file)
-			if not os.path.exists(expandedFile):
-				print(f"\tCreating file: {expandedFile}")
-				f = open(expandedFile, "w+")
-				f.close()
+        for file in fileList:
+            expandedFile =  os.path.expanduser(file)
+            if not os.path.exists(expandedFile):
+                debug and print(f"\tCreating file: {expandedFile}")
+                f = open(expandedFile, "w+")
+                f.close()
 
-		# Initialize timestamp to zero
-		fileDict={}.fromkeys(fileList,0)
-		return fileDict
+        # Initialize timestamp to zero
+        fileDict={}.fromkeys(fileList,0)
+        return fileDict
 
-	def createDirectories():
+    def createDirectories(debug):
 
-		for directory in CommonFileSystem.dirList:
-			
-			expandedDir =  os.path.expanduser(directory)
-			if os.path.exists(expandedDir):
-				print(f"\tDirectory {expandedDir} exists.")
-				continue
+        for directory in CommonFileSystem.dirList:
+            
+            expandedDir =  os.path.expanduser(directory)
+            if os.path.exists(expandedDir):
+                debug and print(f"\tDirectory {expandedDir} exists.")
+                continue
 
-			try:
-				print(f"\tCreating directory: {expandedDir}")
-				os.mkdir(expandedDir)
-			except OSError as e:
-				print(e)
-			
+            try:
+                debug and print(f"\tCreating directory: {expandedDir}")
+                os.mkdir(expandedDir)
+            except OSError as e:
+                print(e)
+            
 
-	def removeDirectories():
+    def removeDirectories(debug):
 
-		for directory in CommonFileSystem.dirList:
-			
-			expandedDir =  os.path.expanduser(os.path.expandvars(directory))
-			try:
-				if os.path.exists(expandedDir):
-					print(f"\tRemoving directory: {expandedDir}")
-					shutil.rmtree(expandedDir)		
-			except OSError as e:
-				print(e)
-			
+        for directory in CommonFileSystem.dirList:
+            
+            expandedDir =  os.path.expanduser(os.path.expandvars(directory))
+            try:
+                if os.path.exists(expandedDir):
+                    debug and print(f"\tRemoving directory: {expandedDir}")
+                    shutil.rmtree(expandedDir)        
+            except OSError as e:
+                print(e)
+            
 
-	def getMTime(aPath):
-		mtime = Path(aPath).stat().st_mtime
+    def getMTime(aPath):
+        mtime = Path(aPath).stat().st_mtime
 
-		print(f"\tCurrent mtime: \t{CommonFileSystem.convertEpochToHumanDate(mtime)} - ({int(mtime)}) for {aPath}")
-		
-		return int(mtime) 
-
-
-	def changeMTime(aPath, secondsIncrement):
-		mtime = Path(aPath).stat().st_mtime
-
-		#with open(precipitation, 'wt') as f: pass
-		result = os.stat(Path(aPath))
-
-		# change mtime:
-		currentTimeEpoch = int(time.time())
-		negativeNewTimeEpoch = currentTimeEpoch - secondsIncrement
-		os.utime(aPath, (negativeNewTimeEpoch, negativeNewTimeEpoch))
-#		os.utime(aPath, (result.st_atime + secondsIncrement, result.st_mtime + secondsIncrement))
-		result = os.stat(aPath)
-		print(f"\tNew mtime: \t{CommonFileSystem.convertEpochToHumanDate(int(result.st_mtime))} - ({int(result.st_mtime)}) for {aPath}")
-
-		return int(result.st_mtime)
-		
-
-	def convertEpochToHumanDate(epochTime):
-
-		
-		mtime = time.gmtime(epochTime)
-		#time.struct_time(tm_year=2012, tm_mon=8, tm_mday=28, tm_hour=0, tm_min=45, tm_sec=17, tm_wday=1, tm_yday=241, tm_isdst=0)  
-
-		humanTime = time.strftime('%m/%d/%Y %H:%M:%S',  time.gmtime(epochTime))
-		# '08/28/2012 00:45:17'
-
-		return humanTime
+        print(f"\tCurrent mtime: \t{CommonFileSystem.convertEpochToHumanDate(mtime)} - ({int(mtime)}) for {aPath}")
+        
+        return int(mtime) 
 
 
+    def changeMTime(aPath, secondsIncrement):
+        mtime = Path(aPath).stat().st_mtime
 
-	def executeCscour(deleteFlag, ingestFile):
-		
-		outPutfile = "/tmp/scour_log.txt"
+        #with open(precipitation, 'wt') as f: pass
+        result = os.stat(Path(aPath))
 
-		if deleteFlag == "-d":
-			with open(outPutfile, "w+") as scourLog:
-				process = subprocess.run(["./Cscour", "-v",  "-d", ingestFile], stdout=scourLog)
-	
-			#cmd = f"./Cscour -v -d {ingestFile} > {outPutfile}"
-			#os.system(cmd)
-		
+        # change mtime:
+        currentTimeEpoch = int(time.time())
+        negativeNewTimeEpoch = currentTimeEpoch - secondsIncrement
+        os.utime(aPath, (negativeNewTimeEpoch, negativeNewTimeEpoch))
+#        os.utime(aPath, (result.st_atime + secondsIncrement, result.st_mtime + secondsIncrement))
+        result = os.stat(aPath)
+        print(f"\tNew mtime: \t{CommonFileSystem.convertEpochToHumanDate(int(result.st_mtime))} - ({int(result.st_mtime)}) for {aPath}")
 
-	def unwrapIt(text):
-		s=""
-		for i in text:
-			#if chr(i) == '\n': continue
-			
-			s+= chr(i)
-		
-		return s
-		
+        return int(result.st_mtime)
+        
+
+    def convertEpochToHumanDate(epochTime):
+
+        
+        mtime = time.gmtime(epochTime)
+        #time.struct_time(tm_year=2012, tm_mon=8, tm_mday=28, tm_hour=0, tm_min=45, tm_sec=17, tm_wday=1, tm_yday=241, tm_isdst=0)  
+
+        humanTime = time.strftime('%m/%d/%Y %H:%M:%S',  time.gmtime(epochTime))
+        # '08/28/2012 00:45:17'
+
+        return humanTime
+
+
+
+    def executeCscour(deleteFlag, ingestFile):
+        
+        outPutfile = "/tmp/scour_log.txt"
+
+        print(f"\t./scour -v  -d {ingestFile}") 
+#, stdout=scourLog)
+        if deleteFlag == "-d":
+            with open(outPutfile, "w+") as scourLog:
+                process = subprocess.run(["./Cscour", "-v",  "-d", ingestFile]) #, stdout=scourLog)
+    
+            #cmd = f"./Cscour -v -d {ingestFile} > {outPutfile}"
+            #os.system(cmd)
+        
+
+    def unwrapIt(text):
+        s=""
+        for i in text:
+            #if chr(i) == '\n': continue
+            
+            s+= chr(i)
+        
+        return s
+        
 
 
 # Scenario: 
-#	- Create a directory tree
-#	- Create a symlink to a file eligible for deletion
-#	- Create  a directory symlink
-# 	Expected:
-#	- file gets deleted and its symlink too
-#	- directory becomes empty (all its scoured files are deleted OR some files remain)
+#    - Create a directory tree
+#    - Create a symlink to a file eligible for deletion
+#    - Create  a directory symlink
+#     Expected:
+#    - file gets deleted and its symlink too
+#    - directory becomes empty (all its scoured files are deleted OR some files remain)
 #   - directory (and its symlink) is not deleted.
 
-class SymlinkDeletion:	
+class SymlinkDeletion:    
 
-	fileList=[	"/tmp/vesuvius/.scour$*.txt", 
-				"/tmp/vesuvius/precipitation.foo",
-				"/tmp/vesuvius/precipitation.txt",
-				"/tmp/etna/precipitation.txt",
-				"/tmp/etna/alt_dir/precipitation.txt",
-				"/tmp/etna/vesuvius.foo",
-				"/tmp/etna/.scour$*.foo"
-	]
-	fileToSymlinkDict={
-				"/tmp/etna/precipitation.txt": "/tmp/vesuvius/sl_etna_file",
-				"/tmp/etna/alt_dir": "/tmp/vesuvius/sl_etna_alt_dir"
-	}
+    fileList=[    "/tmp/vesuvius/.scour$*.txt", 
+                "/tmp/vesuvius/precipitation.foo",
+                "/tmp/vesuvius/precipitation.txt",
+                "/tmp/etna/precipitation.txt",
+                "/tmp/etna/alt_dir/precipitation.txt",
+                "/tmp/etna/vesuvius.foo",
+                "/tmp/etna/.scour$*.foo"
+    ]
+    fileToSymlinkDict={
+                "/tmp/etna/precipitation.txt": "/tmp/vesuvius/sl_etna_file",
+                "/tmp/etna/alt_dir": "/tmp/vesuvius/sl_etna_alt_dir"
+    }
 
-	def __init__(self):
-		
-		self.ingestFile 	= "/tmp/scourTest.conf"
-		#self.entries 		= "/tmp/vesuvius		2	*.txt\n/tmp/etna		7-1130	*.foo"
-		self.entries 		= "/tmp/vesuvius		2	*.txt"
-		self.daysOldInSecs 	= 172800 			# seconds: 2 * 24 * 3600 s
+    def __init__(self):
+        
+        self.ingestFile     = "/tmp/scourTest.conf"
+        #self.entries         = "/tmp/vesuvius        2    *.txt\n/tmp/etna        7-1130    *.foo"
+        self.entries         = "/tmp/vesuvius        2    *.txt"
+        self.daysOldInSecs     = 172800             # seconds: 2 * 24 * 3600 s
 
-		# Create the scour config file with entries 
-		# for Cscour to use as CLI argument
-		f = open(self.ingestFile, "w+")
-		f.write(self.entries)
-		f.close()
+        # Create the scour config file with entries 
+        # for Cscour to use as CLI argument
+        f = open(self.ingestFile, "w+")
+        f.write(self.entries)
+        f.close()
 
-	def __str__(self):
-		return f"{self.filename}  {self.timestamp}"
+    def __str__(self):
+        return f"{self.filename}  {self.timestamp}"
 
-	def __eq__(self, other):
-		if self.filename == other.filename:
-			return true
-		return false
+    def __eq__(self, other):
+        if self.filename == other.filename:
+            return true
+        return false
 
-	def createSymlinks(self):
+    def createSymlinks(self, debug):
 
-		print(f"\nScour config file entrie(s): \n\t--> {self.entries}")
+        debug and print(f"\nScour config file entrie(s): \n\t--> {self.entries}")
 
-		print(f"\nCreate symlink(s): ")
+        print(f"\nCreate symlink(s): ")
 
-		for kTarget, vLink  in self.fileToSymlinkDict.items():
-			expandedTarget =  os.path.expanduser(kTarget)
-			expandedLink =  os.path.expanduser(vLink)
+        for kTarget, vLink  in self.fileToSymlinkDict.items():
+            expandedTarget =  os.path.expanduser(kTarget)
+            expandedLink =  os.path.expanduser(vLink)
 
-			print(f"\t{expandedLink} \t--> {expandedTarget}")
-			if not os.path.exists(expandedLink):
-				os.symlink(expandedTarget, expandedLink)
-			
-		print("\n")
-
-
-	def markEligibleForDeletion(self, daysOldInSecs):
-
-		# Set mtime to appropriate value to have file deleted
-		# for kTarget, vLink  in self.fileToSymlinkDict.items():
-		# 	expandedTarget =  os.path.expanduser(kTarget)
-		# 	expandedLink =  os.path.expanduser(vLink)
-		# 	CommonFileSystem.changeMTime(expandedTarget, daysOldInSecs)
-
-		# make .scour$*.txt NEWER than precipitation.txt
-		# Expect precipitation.txt to be deleted.
-		
-	#	scourFile=os.path.expanduser("/tmp/vesuvius/.scour$*.txt")
-	#	CommonFileSystem.changeMTime(scourFile, daysOldInSecs)
+            print(f"\t{expandedLink} \t--> {expandedTarget}")
+            if not os.path.exists(expandedLink):
+                os.symlink(expandedTarget, expandedLink)
+            
+        print("\n")
 
 
-		# make precipitation.txt OLDER than 2days +50secs
-		# Expect precipitation.txt to be deleted.
-		aFile=os.path.expanduser("/tmp/vesuvius/precipitation.txt")
-		CommonFileSystem.changeMTime(aFile, 2 * daysOldInSecs +50)
+    def markEligibleForDeletion(self, daysOldInSecs):
+
+        # Set mtime to appropriate value to have file deleted
+        # for kTarget, vLink  in self.fileToSymlinkDict.items():
+        #     expandedTarget =  os.path.expanduser(kTarget)
+        #     expandedLink =  os.path.expanduser(vLink)
+        #     CommonFileSystem.changeMTime(expandedTarget, daysOldInSecs)
+
+        # make .scour$*.txt NEWER than precipitation.txt
+        # Expect precipitation.txt to be deleted.
+        
+    #    scourFile=os.path.expanduser("/tmp/vesuvius/.scour$*.txt")
+    #    CommonFileSystem.changeMTime(scourFile, daysOldInSecs)
 
 
-		aFile=os.path.expanduser("/tmp/etna/alt_dir/precipitation.txt")
-		CommonFileSystem.changeMTime(aFile, daysOldInSecs +50)
+        # make precipitation.txt OLDER than 2days +50secs
+        # Expect precipitation.txt to be deleted.
+        aFile=os.path.expanduser("/tmp/vesuvius/precipitation.txt")
+        CommonFileSystem.changeMTime(aFile, 2 * daysOldInSecs +50)
 
 
-		# make precipitation.txt OLDER than 4 days +50secs
-		# Expect precipitation.txt to be deleted.
-		aFile=os.path.expanduser("/tmp/etna/precipitation.txt")
-		CommonFileSystem.changeMTime(aFile, 2 * daysOldInSecs +50)
+        aFile=os.path.expanduser("/tmp/etna/alt_dir/precipitation.txt")
+        CommonFileSystem.changeMTime(aFile, daysOldInSecs +50)
+
+
+        # make precipitation.txt OLDER than 4 days +50secs
+        # Expect precipitation.txt to be deleted.
+        aFile=os.path.expanduser("/tmp/etna/precipitation.txt")
+        CommonFileSystem.changeMTime(aFile, 2 * daysOldInSecs +50)
 
 
 
-	def createFiles(self):
-		print("\nCreate files:")
-		CommonFileSystem.createFiles(self.fileList)
+    def createFiles(self, debug):
+        debug and print("\nCreate files:")
+        CommonFileSystem.createFiles(self.fileList, debug)
 
 
-	def runScenario(self, deleteFlag):
-		self.createFiles()
-		self.createSymlinks()
-		self.markEligibleForDeletion(self.daysOldInSecs)
-		
-		
-		print(f"\n\tExecuting Scour...\n")
-		CommonFileSystem.executeCscour(deleteFlag, self.ingestFile)
-		
-		print(f"\n\tRunning assertions...\n")
-		return self.assertSymlink()
+    def runScenario(self, deleteFlag, debug):
+        self.createFiles(debug)
+        self.createSymlinks(debug)
+        self.markEligibleForDeletion(self.daysOldInSecs)
+        
+        if debug:
+            yes_no = input("Execute scour?")
+            if yes_no == "n":
+                exit(0)
+
+        print(f"\n\tExecuting Scour...\n")
+        CommonFileSystem.executeCscour(deleteFlag, self.ingestFile)
+        
+        print(f"\n\tRunning assertions...\n")
+        return self.assertSymlink()
 
 
-	def assertSymlink(self):
-		
-		status=0
+    def assertSymlink(self):
+        
+        status=0
 
-		# Files:
-		print(f"\nFILES: --------------------------------------")
-		aPath=os.path.expanduser("/tmp/etna/alt_dir/precipitation.txt")
-		if not os.path.exists(aPath): 
-			print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_FILE_DELETED}: {aPath}")
-		else:
-			print(f"\t{ASSERT_FAIL}: \t{ASSERT_FILE_DELETED}: {aPath}")
-			status=1
+        # Files:
+        print(f"\nFILES: --------------------------------------")
+        aPath=os.path.expanduser("/tmp/etna/alt_dir/precipitation.txt")
+        if not os.path.exists(aPath): 
+            print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_FILE_DELETED}: {aPath}")
+        else:
+            print(f"\t{ASSERT_FAIL}: \t{ASSERT_FILE_DELETED}: {aPath}")
+            status=1
 
-		aPath=os.path.expanduser("/tmp/vesuvius/precipitation.txt")
-		if not os.path.exists(aPath): 
-			print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_FILE_DELETED}: {aPath}")
-		else:
-			print(f"\t{ASSERT_FAIL}: \t{ASSERT_FILE_DELETED}: {aPath}")
-			status=1
+        aPath=os.path.expanduser("/tmp/vesuvius/precipitation.txt")
+        if not os.path.exists(aPath): 
+            print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_FILE_DELETED}: {aPath}")
+        else:
+            print(f"\t{ASSERT_FAIL}: \t{ASSERT_FILE_DELETED}: {aPath}")
+            status=1
 
-		aPath=os.path.expanduser("/tmp/etna/precipitation.txt")
-		if not os.path.exists(aPath): 
-			print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_FILE_DELETED}: {aPath}")
-		else:
-			print(f"\t{ASSERT_FAIL}: \t{ASSERT_FILE_DELETED}: {aPath}")
-			status=1
+        aPath=os.path.expanduser("/tmp/etna/precipitation.txt")
+        if not os.path.exists(aPath): 
+            print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_FILE_DELETED}: {aPath}")
+        else:
+            print(f"\t{ASSERT_FAIL}: \t{ASSERT_FILE_DELETED}: {aPath}")
+            status=1
 
-		# Symlinks
-		
-		# "/tmp/etna/precipitation.txt": "/tmp/vesuvius/sl_etna_file",
-		# "/tmp/etna/alt_dir": "/tmp/vesuvius/sl_etna_alt_dir"
-		print(f"\nSYMLINKs: --------------------------------------")
-		kTarget	= "/tmp/etna/precipitation.txt"
-		vLink 	= "/tmp/vesuvius/sl_etna_file"
-		expandedTarget =  os.path.expanduser(kTarget)
-		expandedLink =  os.path.expanduser(vLink)
+        # Symlinks
+        
+        # "/tmp/etna/precipitation.txt": "/tmp/vesuvius/sl_etna_file",
+        # "/tmp/etna/alt_dir": "/tmp/vesuvius/sl_etna_alt_dir"
+        print(f"\nSYMLINKs: --------------------------------------")
+        kTarget    = "/tmp/etna/precipitation.txt"
+        vLink     = "/tmp/vesuvius/sl_etna_file"
+        expandedTarget =  os.path.expanduser(kTarget)
+        expandedLink =  os.path.expanduser(vLink)
 
 
-		print(f"\t{expandedLink} --> {expandedTarget}")
-		if 	not os.path.exists(expandedTarget)	\
-			and not os.path.islink(expandedLink):
-			
-			print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_FILE_LINK_DELETED}: {expandedLink}")			
-			print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_FILE_DELETED}: {expandedTarget}")
-		else:
-			if os.path.exists(expandedTarget)	\
-				or os.path.islink(expandedLink):
-					
-				print(f"\n\t{ASSERT_FAIL}: \tUn-Expected SymLink behavior! ({expandedTarget} - {expandedLink})  ")
-				status=1	
+        print(f"\t{expandedLink} --> {expandedTarget}")
+        if     not os.path.exists(expandedTarget)    \
+            and not os.path.islink(expandedLink):
+            
+            print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_FILE_LINK_DELETED}: {expandedLink}")            
+            print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_FILE_DELETED}: {expandedTarget}")
+        else:
+            if os.path.exists(expandedTarget)    \
+                or os.path.islink(expandedLink):
+                    
+                print(f"\n\t{ASSERT_FAIL}: \tUn-Expected SymLink behavior! ({expandedTarget} - {expandedLink})  ")
+                status=1    
 
-		# "/tmp/etna/alt_dir": "/tmp/vesuvius/sl_etna_alt_dir"
-		kTarget	= "/tmp/etna/alt_dir"
-		vLink 	= "/tmp/vesuvius/sl_etna_alt_dir"
-		expandedTarget =  os.path.expanduser(kTarget)
-		expandedLink =  os.path.expanduser(vLink)
+        # "/tmp/etna/alt_dir": "/tmp/vesuvius/sl_etna_alt_dir"
+        kTarget    = "/tmp/etna/alt_dir"
+        vLink     = "/tmp/vesuvius/sl_etna_alt_dir"
+        expandedTarget =  os.path.expanduser(kTarget)
+        expandedLink =  os.path.expanduser(vLink)
 
-		print(f"\t{expandedLink} --> {expandedTarget}")
-		# Do not delete directory and its symlink
-		if 	os.path.exists(expandedTarget) 		\
-			and os.path.isdir(expandedTarget) 	\
-			and os.path.exists(expandedLink) 	\
-			and os.path.islink(expandedLink): 
+        print(f"\t{expandedLink} --> {expandedTarget}")
+        # Do not delete directory and its symlink
+        if     os.path.exists(expandedTarget)         \
+            and os.path.isdir(expandedTarget)     \
+            and os.path.exists(expandedLink)     \
+            and os.path.islink(expandedLink): 
 
-			print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_DIR_LINK_NOT_DELETED}: {expandedTarget}")				
+            print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_DIR_LINK_NOT_DELETED}: {expandedTarget}")                
 
-		else:
-			if 	not os.path.exists(expandedTarget) 		\
-				or not os.path.islink(expandedLink): 
+        else:
+            if     not os.path.exists(expandedTarget)         \
+                or not os.path.islink(expandedLink): 
 
-				print(f"\t{ASSERT_FAIL}: \t{ASSERT_DIR_LINK_NOT_DELETED}: {expandedTarget}")				
-	
-				status=1
+                print(f"\t{ASSERT_FAIL}: \t{ASSERT_DIR_LINK_NOT_DELETED}: {expandedTarget}")                
+    
+                status=1
 
-		return status	
+        return status    
 
 
 # Scenario: 
-#	- Create a directory tree with files that all eligible for deletion (no symlink)
-#	- Expected: all tree gets deleted
+#    - Create a directory tree with files that all eligible for deletion (no symlink)
+#    - Expected: all tree gets deleted
 
 class EmptyDirectoriesDeletion:
 
-	fileList=["/tmp/etna/precipitation.txt",
-				"/tmp/etna/alt_dir/precipitation.txt"
-	]
+    fileList=["/tmp/etna/precipitation.txt",
+                "/tmp/etna/alt_dir/precipitation.txt"
+    ]
 
-	dirList=[
-			"/tmp/vesuvius",
-			"/tmp/etna",
-			"/tmp/etna/alt_dir"
-	]
-	
-	def __init__(self):
-		
-		self.ingestFile = "/tmp/scourTest.conf"
-		#self.entries 	= "/tmp/vesuvius		2	*.txt\n/tmp/etna		7-1130	*.foo"
-		self.entries 	= "/tmp/etna		2	*.txt\
-		 \n/tmp/dirDoesNotExist		2	*.txt"
-		self.daysOldInSecs 	= 172800 			# seconds: 2 * 24 * 3600 s
+    dirList=[
+            "/tmp/vesuvius",
+            "/tmp/etna",
+            "/tmp/etna/alt_dir"
+    ]
+    
+    def __init__(self):
+        
+        self.ingestFile = "/tmp/scourTest.conf"
+        #self.entries     = "/tmp/vesuvius        2    *.txt\n/tmp/etna        7-1130    *.foo"
+        self.entries     = "/tmp/etna        2    *.txt\
+         \n/tmp/dirDoesNotExist        2    *.txt"
+        self.daysOldInSecs     = 172800             # seconds: 2 * 24 * 3600 s
 
-		# Create the scour config file with entries 
-		# for Cscour to use as CLI argument
-		f = open(self.ingestFile, "w+")
-		f.write(self.entries)
-		f.close()
+        # Create the scour config file with entries 
+        # for Cscour to use as CLI argument
+        f = open(self.ingestFile, "w+")
+        f.write(self.entries)
+        f.close()
 
-	def __str__(self):
-		return f"{self.filename}  {self.timestamp}"
+    def __str__(self):
+        return f"{self.filename}  {self.timestamp}"
 
-	def __eq__(self, other):
-		if self.filename == other.filename:
-			return true
-		return false
-
-
-	def createFiles(self):
-
-		print("\nCreate files:")
-		CommonFileSystem.createFiles(self.fileList)
+    def __eq__(self, other):
+        if self.filename == other.filename:
+            return true
+        return false
 
 
-	def markEligibleForDeletion(self, daysOldInSecs):
+    def createFiles(self, debug):
 
-		# Set mtime to appropriate value to have file(s) deleted
-		
-		# TO REMOVE:
-		# "/tmp/etna/precipitation.txt",
-		# "/tmp/etna/alt_dir/precipitation.txt",
-		# "/tmp/etna",
-		# "/tmp/etna/alt_dir"		
-
-		# make precipitation.txt OLDER than 4 days +50secs
-		# Expect precipitation.txt to be deleted.
-		aFile=os.path.expanduser("/tmp/etna/precipitation.txt")
-		CommonFileSystem.changeMTime(aFile, 2 * daysOldInSecs +50)
-
-		aFile=os.path.expanduser("/tmp/etna/alt_dir/precipitation.txt")
-		CommonFileSystem.changeMTime(aFile, daysOldInSecs +50)
+        debug and print("\nCreate files:")
+        CommonFileSystem.createFiles(self.fileList, debug)
 
 
-	def runScenario(self, deleteFlag):
-		self.createFiles()
-		self.markEligibleForDeletion(self.daysOldInSecs)
-		
-		print(f"\n\tExecuting Scour...\n")
-		CommonFileSystem.executeCscour(deleteFlag, self.ingestFile)
-		
-		print(f"\n\tRunning assertions...\n")
-		
-		return self.assertDirectoriesRemoved()
+    def markEligibleForDeletion(self, daysOldInSecs):
+
+        # Set mtime to appropriate value to have file(s) deleted
+        
+        # TO REMOVE:
+        # "/tmp/etna/precipitation.txt",
+        # "/tmp/etna/alt_dir/precipitation.txt",
+        # "/tmp/etna",
+        # "/tmp/etna/alt_dir"        
+
+        # make precipitation.txt OLDER than 4 days +50secs
+        # Expect precipitation.txt to be deleted.
+        aFile=os.path.expanduser("/tmp/etna/precipitation.txt")
+        CommonFileSystem.changeMTime(aFile, 2 * daysOldInSecs +50)
+
+        aFile=os.path.expanduser("/tmp/etna/alt_dir/precipitation.txt")
+        CommonFileSystem.changeMTime(aFile, daysOldInSecs +50)
 
 
-	def assertDirectoriesRemoved(self):
-		
-		status=0
+    def runScenario(self, deleteFlag, debug):
+        self.createFiles(debug)
+        self.markEligibleForDeletion(self.daysOldInSecs)
+        
+        print(f"\n\tExecuting scour(1)...\n")
+        CommonFileSystem.executeCscour(deleteFlag, self.ingestFile)
+        
+        print(f"\n\tRunning assertions...\n")
+        
+        return self.assertDirectoriesRemoved()
 
-		# Files:
-		print(f"\nFILES: --------------------------------------")
-		
-		aPath=os.path.expanduser("/tmp/etna/alt_dir/precipitation.txt")
-		if not os.path.exists(aPath): 
-			print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_FILE_DELETED}: {aPath}")
-		else:
-			print(f"\t{ASSERT_FAIL}: \t{ASSERT_FILE_DELETED}: {aPath}")
-			status=1
 
-		aPath=os.path.expanduser("/tmp/etna/precipitation.txt")
-		if not os.path.exists(aPath): 
-			print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_FILE_DELETED}: {aPath}")
-		else:
-			print(f"\t{ASSERT_FAIL}: \t{ASSERT_FILE_DELETED}: {aPath}")
-			status=1
+    def assertDirectoriesRemoved(self):
+        
+        status=0
 
-		# Directories
-		print(f"\nDIRECTORIES: --------------------------------------")
+        # Files:
+        print(f"\nFILES: --------------------------------------")
+        
+        aPath=os.path.expanduser("/tmp/etna/alt_dir/precipitation.txt")
+        if not os.path.exists(aPath): 
+            print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_FILE_DELETED}: {aPath}")
+        else:
+            print(f"\t{ASSERT_FAIL}: \t{ASSERT_FILE_DELETED}: {aPath}")
+            status=1
 
-		aPath=os.path.expanduser("/tmp/etna/alt_dir")
-		if not os.path.exists(aPath): 
-			print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_DIR_DELETED}: {aPath}")
-		else:
-			print(f"\t{ASSERT_FAIL}: \t{ASSERT_DIR_DELETED}: {aPath}")
-			status=1
-		
-		aPath=os.path.expanduser("/tmp/etna")
-		if not os.path.exists(aPath): 
-			print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_DIR_DELETED}: {aPath}")
-		else:
-			print(f"\t{ASSERT_FAIL}: \t{ASSERT_DIR_DELETED}: {aPath}")
-			status=1
+        aPath=os.path.expanduser("/tmp/etna/precipitation.txt")
+        if not os.path.exists(aPath): 
+            print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_FILE_DELETED}: {aPath}")
+        else:
+            print(f"\t{ASSERT_FAIL}: \t{ASSERT_FILE_DELETED}: {aPath}")
+            status=1
 
-		aPath=os.path.expanduser("/tmp/dirDoesNotExist")
-		if not os.path.exists(aPath): 
-			print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_NOT_DIR}: {aPath}")
-		else:
-			print(f"\t{ASSERT_FAIL}: \t{ASSERT_NOT_DIR}: {aPath}")
-			status=1
+        # Directories
+        print(f"\nDIRECTORIES: --------------------------------------")
 
-		return status
+        aPath=os.path.expanduser("/tmp/etna/alt_dir")
+        if not os.path.exists(aPath): 
+            print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_DIR_DELETED}: {aPath}")
+        else:
+            print(f"\t{ASSERT_FAIL}: \t{ASSERT_DIR_DELETED}: {aPath}")
+            status=1
+        
+        aPath=os.path.expanduser("/tmp/etna")
+        if not os.path.exists(aPath): 
+            print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_DIR_DELETED}: {aPath}")
+        else:
+            print(f"\t{ASSERT_FAIL}: \t{ASSERT_DIR_DELETED}: {aPath}")
+            status=1
+
+        aPath=os.path.expanduser("/tmp/dirDoesNotExist")
+        if not os.path.exists(aPath): 
+            print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_NOT_DIR}: {aPath}")
+        else:
+            print(f"\t{ASSERT_FAIL}: \t{ASSERT_NOT_DIR}: {aPath}")
+            status=1
+
+        return status
 
 def main():
 
-		print("\n\t========= Symlink Deletion scenario ================\n")
-		print("\nTear down directories:")
-		CommonFileSystem.removeDirectories()
-		print("\nCreate directories:")
-		CommonFileSystem.createDirectories()
-		sl = SymlinkDeletion()
-		sl_status = sl.runScenario("-d")
+        cliParser = argparse.ArgumentParser(
+            prog='testCscour.py',
+            description='''This file is the test file for Cscour(1) .''',
+            usage='''%(prog)s [-x]\n''',
+            epilog='''
+
+            '''
+            )
+        cliParser.add_argument('-x', action='store_true', help='debug')
+        args = cliParser.parse_args()
+        debug = args.x
+        debug and system('clear')
+
+        debug and print("\n\t========= Symlink Deletion scenario ================\n")
+        debug and print("\nTear down directories:")
+        CommonFileSystem.removeDirectories(debug)
+        debug and print("\nCreate directories:")
+        CommonFileSystem.createDirectories(debug)
+        sl = SymlinkDeletion()
+        sl_status = sl.runScenario("-d", debug)
 
 
-		print("\n\t========== EmptyDirectories Deletion scenario =======\n")
-		print("\nTear down directories:")
-		CommonFileSystem.removeDirectories()
-		print("\nCreate directories:")
-		CommonFileSystem.createDirectories()
-		ed = EmptyDirectoriesDeletion()
-		ed_status = ed.runScenario("-d")
-		
-		print(f"sl_status: {sl_status} ed_status: {ed_status}")
-		exit( ed_status * sl_status )
+        print("\n\t========== EmptyDirectories Deletion scenario =======\n")
+        debug and print("\nTear down directories:")
+        CommonFileSystem.removeDirectories(debug)
+        debug and print("\nCreate directories:")
+        CommonFileSystem.createDirectories(debug)
+        ed = EmptyDirectoriesDeletion()
+        ed_status = ed.runScenario("-d", debug)
+        
+        debug and print(f"sl_status: {sl_status} ed_status: {ed_status}")
+
+        exit( ed_status * sl_status )
 
 if __name__ == '__main__':
-		main()
+        main()


### PR DESCRIPTION
- In main(): Added setting scour config file to a default value (in /etc). 
- When executing configure: corrected path ($HOME/ldm/`pwd`) to generate the config.h path entry correctly.
- Added entry in configure.ac for scour(1) config-file default value.
- Moved the parsing code from parser.c to main() function in Cscour.c where it traditionally belongs.
- Refactored the scour config-file and excludes file path validation code.