### PR TITLE
Mi scour ghost dir handling

### DIFF
--- a/scour/scour.c
+++ b/scour/scour.c
@@ -85,6 +85,8 @@ isDirectoryEmpty(char* dirname)
     DIR *dir = opendir(dirname);
     if( dir == NULL)
     {
+        log_add("failed to open directory \"%s\" (%d: %s)", dirname, errno, strerror(errno));
+        log_flush_error();
         return NON_EXISTENT_DIR;
     }
 
@@ -342,8 +344,6 @@ scourFilesAndDirs(char *basePath, time_t daysOldInEpoch,
             int dirStatus = isDirectoryEmpty(absPath);
             if (dirStatus == NON_EXISTENT_DIR)
             {
-                log_add("directory (\"%s\") does not exist (opendir() failed)", absPath);
-                log_flush_error();
                 break;
             }
             // Remove if empty and not symlinked, regardless of its age (daysOld)

--- a/scour/testCscour.py
+++ b/scour/testCscour.py
@@ -256,6 +256,11 @@ class SymlinkDeletion:
     ]
       
 
+    expectedNonExistentDirectorySkippedList = [
+        "/tmp/vesuvius/dirDoesNotExist"                  # should NOT be deleted (from /tmp/excludes.txt)
+    ]
+
+
     def __init__(self, debug):
         
         self.ingestFile = "/tmp/scourTest.conf"
@@ -437,9 +442,25 @@ class SymlinkDeletion:
                 status=1
 
 
+        print("")
+        # 'not-a-directory' (directory does not exists: no scouring BUT no system crash either.)
+        #  ASSERT_NOT_DIR    = "Expect 'not-a-directory' to be skipped from scouring"
+
+        # ========================== NON-EXISTENT DIRECTORIES: to escape scouring ===========
+        print(f"\nSkip scouring non-existent dirs: ---------- (expect no crash) ------")
+
+        # expectedNonExistentDirectorySkippedList
+        for file in self.expectedNonExistentDirectorySkippedList:
+            aPath=os.path.expanduser(file)
+            if not os.path.exists(aPath): 
+                print(f"\t{ASSERT_SUCCESS}: \t{ASSERT_NOT_DIR}: {aPath}")
+            else:
+                print(f"\t{ASSERT_FAIL}: \t{ASSERT_NOT_DIR}: {aPath}")
+                status=1
+
+
         print("\n\n")
-        # Not covered: 'not-a-directory' (directory does not exists: skipped)
-        #   ASSERT_NOT_DIR                  = "Expect 'not-a-directory' to be skipped"
+        
 
 
         return status    


### PR DESCRIPTION
scour: added check on opendir() to verify if directory does not exist or opendir() returns NULL and thus cannot be used in subsequent readdir() system call (will cause a crash).