### PR TITLE
Fix parallel compilation of pqing/do.c

### DIFF
--- a/misc/FixedDelayQueue.h
+++ b/misc/FixedDelayQueue.h
@@ -19,6 +19,7 @@
 #include <mutex>
 #include <queue>
 #include <thread>
+#include <stdexcept>
 
 /**
  * @tparam Value     Type of value being stored in the queue. Must support

--- a/pqing/Makefile.am
+++ b/pqing/Makefile.am
@@ -61,9 +61,9 @@ pqing.1:	$(srcdir)/pqing.1.in
 	mv $@.tmp $@
 
 do_check.o:	do.c
-	$(COMPILE) -DSCAN_CHECK -c $(srcdir)/do.c && mv do.o $@;
+	$(COMPILE) -DSCAN_CHECK -c -o $@ $(srcdir)/do.c
 do_nocheck.o:	do.c
-	$(COMPILE) -USCAN_CHECK -c $(srcdir)/do.c && mv do.o $@;
+	$(COMPILE) -USCAN_CHECK -c -o $@ $(srcdir)/do.c
 
 install-exec-hook:
 	cd $(DESTDIR)$(bindir) && rm -f dds && ln -s $(bin_PROGRAMS) dds


### PR DESCRIPTION
When calling `make -j$(nproc)`, there is a possibility for two versions of `do.o` to be compiled simultaneously, making `mv` fail. I write the correct `.o` file directly instead.

I also added `#include <stdexcept>` to `misc/FixedDelayQueue.h` for the definition of `std::runtime_error` to fix compilation under Ubuntu 24.04.